### PR TITLE
Adding "Deprecate" info.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+
+NOTICE: THIS REPO IS DEPRECATED! onnx-mxnet has been merge into [MXNet](https://github.com/apache/incubator-mxnet/tree/master/python/mxnet/contrib/onnx/_import). 
+Please refer to [API docs](http://mxnet.incubator.apache.org/versions/1.2.0/api/python/contrib/onnx.html) for more details.
+=======
 # ONNX-MXNet
 
 | ubuntu/python-2.7 | ubuntu/python-3.5 |


### PR DESCRIPTION
With MXNet 1.2 release, we have added support for ONNX import inside mxnet. Deprecating this repo.

